### PR TITLE
build: add option to turn off test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,12 +23,13 @@ project(
 
 # Follow GNU conventions for installing directories
 include(GNUInstallDirs)
+include(CTest) # option(BUILD_TESTING). ON by default.
 
 # General configuration information
 add_subdirectory("config")
 
 # Collect subprojects
-if(NOT TARGET "test-drive::test-drive" AND ENABLE_TESTING)
+if(NOT TARGET "test-drive::test-drive" AND BUILD_TESTING)
   find_package("test-drive" REQUIRED)
 endif()
 if(NOT TARGET "toml-f::toml-f")
@@ -101,7 +102,7 @@ install(
   DESTINATION "${CMAKE_INSTALL_DATADIR}/licenses/${PROJECT_NAME}"
 )
 
-if(ENABLE_TESTING)
+if(BUILD_TESTING)
   # add the testsuite
   enable_testing()
   add_subdirectory("test")

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 option(BUILD_SHARED_LIBS "Whether the libraries built should be shared" FALSE)
-option(ENABLE_TESTING "Whether the libraries built should be tested" TRUE)
 
 set(
   "${PROJECT_NAME}-module-dir"

--- a/meson.build
+++ b/meson.build
@@ -77,4 +77,6 @@ if install
 endif
 
 # add the testsuite
-subdir('test')
+if get_option('tests')
+  subdir('test')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,14 @@
+# This file is part of jonquil.
+# SPDX-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of Apache License, Version 2.0 or MIT license
+# at your option; you may not use this file except in compliance with
+# the License.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+option('tests', type: 'boolean', value: true, description: 'Enable building and running tests')


### PR DESCRIPTION
- add meson option to disable tests
- use [ctest BUILD_TESTING](https://cmake.org/cmake/help/latest/variable/BUILD_TESTING.html) rather than ENABLE_TESTING